### PR TITLE
Add quick code to trim S/A temp files to speed up preliminary validation

### DIFF
--- a/ISAtab-validator_v1.py
+++ b/ISAtab-validator_v1.py
@@ -10,20 +10,33 @@ from tempfile import TemporaryDirectory
 
 isa_config_dir = "./isaconfig-phenotyping-basic"
 isa_tab_dir = argv[1]
+short = 1  # 1: Run validation with shortened s/a files, keeping [num_lines] number of lines.
+num_lines = 3  # should be at least 2 (need the header and 1 row of data).
 
 # Converting all characters to UTF-8
 # ----------------------------------
 
 files = [f for f in os.listdir(isa_tab_dir) if f.endswith('.txt')]
+print('\n* Shortened file validation is ' + ('ENABLED' if short else 'DISABLED') + '. *\n')
 
 with TemporaryDirectory() as tmpdirname:
     print('Created temporary directory:', tmpdirname)
-    print('Converting files to UTF-8.')
+    print('Converting files to UTF-8.\n')
     for f in files:
-        with codecs.open(isa_tab_dir + os.sep + f, 'r') as file:
-            lines = file.read()
-        with codecs.open(tmpdirname + os.sep + f, 'w', encoding='utf8') as file:
-            file.write(lines)
+        if f.lower()[:2] in ['i_', 's_', 'a_']:
+            with codecs.open(isa_tab_dir + os.sep + f, 'r') as file:
+                lines = file.read()
+                if short:
+                    if 'i_' not in f.lower()[:2]:  # investigation files should not be trimmed
+                        lines = lines.split('\n')
+                        if len(lines) > num_lines:
+                            lines = '\n'.join(lines[:num_lines])
+                            print('Trimmed ' + f + ':')
+                            print(lines)  # surviving lines
+                            print()
+
+            with codecs.open(tmpdirname + os.sep + f, 'w', encoding='utf8') as file:
+                file.write(lines)
 
     # Validating ISA-TAB with configuration files
     # -------------------------------------------


### PR DESCRIPTION
I was trying to use the script to validate some bigger datasets, but the process is quite slow. 

As a way to speed up some preliminary testing, I added a few lines so that the temporary study and assay files that are created are shortened: only a few lines are kept in each.

This probably does not run the complete validation that the isatools module does, so it is by no means a substitute for it! But it is a nice way to run those first few tests and detect required columns that are missing, in addition to mistakes in the investigation file.

Though it is a quick-and-dirty hack, I figured that maybe someone else may benefit from it!